### PR TITLE
iOS companion app — sister app to macOS menu bar

### DIFF
--- a/ScrobbleNow.xcodeproj/project.pbxproj
+++ b/ScrobbleNow.xcodeproj/project.pbxproj
@@ -9,41 +9,80 @@
 /* Begin PBXBuildFile section */
 		017C8A218A693DE4F03BEE9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E00961C407B21D13CF45EB9E /* Assets.xcassets */; };
 		0411D4BD98B0A692B918C738 /* MusicBrainzService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7414E9B734282F6B342C5A /* MusicBrainzService.swift */; };
+		04631386DFDB792CA8ED03F8 /* AlbumDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC0CBEE725DC8AF8080E89A /* AlbumDetailView.swift */; };
 		05BA47968FBBFEC344CF9800 /* AlbumDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC0CBEE725DC8AF8080E89A /* AlbumDetailView.swift */; };
+		060E5C068DD007D897484F5C /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE4230F732B9F8257B84158 /* NowPlayingView.swift */; };
 		06B92F41D3E2566A2F416070 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE681000BC36994A602D83 /* KeychainService.swift */; };
 		0BA3EE29324374EE09B50D41 /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB2BB2F20879D5AA4800774 /* LibraryViewModel.swift */; };
+		0CA23012ECB19020988FF852 /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1B44005A77903F50E51973 /* SparklineView.swift */; };
 		11BE473C0BFB47723DEDF381 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AD0226D56AC9B449D3CBE4 /* HistoryView.swift */; };
+		13F5C76719408C9115951E92 /* ScrobbleNowiOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E95E4954D6A90905F67E61A2 /* ScrobbleNowiOSApp.swift */; };
+		182680E9969FE8ED7810258F /* PlatformImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C962FA640E5DCB09F0AA1FFA /* PlatformImage.swift */; };
 		19E221D7BD55284070245C6E /* NowPlayingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922EE3C3F67D7EA943FF2B4F /* NowPlayingViewModel.swift */; };
 		1E021E9EEABAEAE687AC87A6 /* iTunesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB67D6E70719959ED127C567 /* iTunesService.swift */; };
+		1E5216179E621B10E341322D /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE681000BC36994A602D83 /* KeychainService.swift */; };
+		226B44F05BC44BCC453E40A7 /* YouTubeMusicFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BF1538A622E83C2C86506E /* YouTubeMusicFilter.swift */; };
+		23C99D34F4E5D7E56D55A258 /* APITracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC4A8F0FE421C4A49FDEFB0 /* APITracker.swift */; };
+		2465A17A25A6A8B16E2DBEEA /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB2BB2F20879D5AA4800774 /* LibraryViewModel.swift */; };
+		25D07AA16642575B11FCD564 /* WikidataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F556D31BB2BA17C92DBE8A80 /* WikidataService.swift */; };
+		26EF427488E4AB61974433F2 /* ScrobbleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9BDB1C50EA86588165F202 /* ScrobbleCache.swift */; };
 		292661EC3FD2C9201A251D7C /* Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA730E7257F76B5CCDFE472 /* Album.swift */; };
+		2D2B5386EB0355DB8D1D2DA7 /* SystemScrobbleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254BEDF3534B4D7781A96A81 /* SystemScrobbleService.swift */; };
+		2D8CF4034D649388E7205462 /* CacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB479C6E709FA48840511EBB /* CacheService.swift */; };
 		31B182C7ED234C69123A39AB /* YouTubeMusicFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BF1538A622E83C2C86506E /* YouTubeMusicFilter.swift */; };
 		34F13A0C91351C800524B842 /* RadarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A647E4552F30A7374FDCC /* RadarChartView.swift */; };
+		3EE44B8CD0CE384793B91F81 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAB98902C5909700E29F6F7 /* StatisticsView.swift */; };
 		42B1D520A0213B02A7650386 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE4230F732B9F8257B84158 /* NowPlayingView.swift */; };
 		59BC7D098303753E227F2E99 /* AccentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF8BCCC3383C5BF531F7999 /* AccentColor.swift */; };
+		63C5793D3E0BCDBE450F898E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E00961C407B21D13CF45EB9E /* Assets.xcassets */; };
+		699BE5E7825946678B4120EE /* PlatformImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C962FA640E5DCB09F0AA1FFA /* PlatformImage.swift */; };
 		6A4C549A6B7F29C31553C055 /* DiscogsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA4359CB5AB70C4E2E2F729 /* DiscogsService.swift */; };
 		6CFF6CD9103720A4B84760BA /* WikidataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F556D31BB2BA17C92DBE8A80 /* WikidataService.swift */; };
+		6E256F60E0DA83541A6ACBC0 /* MPNowPlayingBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6CF26C04EC1F288F7BF407 /* MPNowPlayingBridge.swift */; };
+		72211E1C53163C98A5AC00C9 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47FEFBAE226AF02FF9AB976 /* LibraryView.swift */; };
+		752BE5B3D2722A9D1A68EF13 /* Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA730E7257F76B5CCDFE472 /* Album.swift */; };
 		76E9B67AC9C98FFCB28AAB01 /* ScrobbleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9BDB1C50EA86588165F202 /* ScrobbleCache.swift */; };
 		77A86A4F46081352DA4AA51F /* CacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB479C6E709FA48840511EBB /* CacheService.swift */; };
 		77B76EF1DE6497F42AB7A1AA /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C98113A7ABDD5E7BDF1F23 /* SettingsManager.swift */; };
 		78C6A2A7C4454084919B997E /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAB98902C5909700E29F6F7 /* StatisticsView.swift */; };
+		794BF6F6EB95B2631952669F /* DiscogsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA4359CB5AB70C4E2E2F729 /* DiscogsService.swift */; };
+		7AC847C1CC26873D42E13F78 /* SystemNowPlaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0C55D55CA394E6FF2818F9 /* SystemNowPlaying.swift */; };
 		7F898C5AA1FE6904631D66EE /* APITracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC4A8F0FE421C4A49FDEFB0 /* APITracker.swift */; };
 		838D457CB4833F9EA3B31F14 /* SystemScrobbleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254BEDF3534B4D7781A96A81 /* SystemScrobbleService.swift */; };
+		8582B339081DFE55C0230AB7 /* LastFMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB4C530B436DAC304D43681 /* LastFMService.swift */; };
 		89DA4AA470CC0A995FFF4E02 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = FE197619BE346D8CE2D36B96 /* Secrets.plist */; };
+		8F37E48851B0BC2B29ED1BD4 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A3650658D9721D4060B6A6 /* StatisticsViewModel.swift */; };
 		8FAECCD67931F57234F4F61D /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47FEFBAE226AF02FF9AB976 /* LibraryView.swift */; };
 		946BD53FD4FFDE08673F91A2 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475214BADE0D94B22F53D601 /* SettingsView.swift */; };
+		95C52601CE30BA78852058F8 /* AlbumDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402CDC8AE6CD24F04BFFC71B /* AlbumDiscoveryService.swift */; };
+		98B24A70524A5C518EF27421 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD2BD832C94BD88F4F7299 /* HistoryViewModel.swift */; };
 		9AAB082D4C52B0BB2986EC91 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A3650658D9721D4060B6A6 /* StatisticsViewModel.swift */; };
+		A06110905BCE6E1233B27F1A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475214BADE0D94B22F53D601 /* SettingsView.swift */; };
 		A3BCFFCFA5E125BF09C74B4E /* AlbumDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402CDC8AE6CD24F04BFFC71B /* AlbumDiscoveryService.swift */; };
+		A4B345FC24488FDF1EB2DDCA /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AD0226D56AC9B449D3CBE4 /* HistoryView.swift */; };
 		A78C2813884ABDE0883B8163 /* LastFMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB4C530B436DAC304D43681 /* LastFMService.swift */; };
+		A7A3A8106E40084102DE1EE1 /* AccentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF8BCCC3383C5BF531F7999 /* AccentColor.swift */; };
 		ACB62FE43B215150A9B93041 /* CollageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A424FB0DA92E827E33FDB9 /* CollageView.swift */; };
+		B31F0CA9754B15949A380E5D /* CollageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A424FB0DA92E827E33FDB9 /* CollageView.swift */; };
+		B5172DDDFBE9FD9323CBEB54 /* Secrets.example.plist in Resources */ = {isa = PBXBuildFile; fileRef = 599193E3C13DA0BF15B628B4 /* Secrets.example.plist */; };
+		BDF75E9C680BDA459A81ABFF /* SystemNowPlaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0C55D55CA394E6FF2818F9 /* SystemNowPlaying.swift */; };
 		C310ACE2A49021CB3CA8EFDF /* Secrets.example.plist in Resources */ = {isa = PBXBuildFile; fileRef = 599193E3C13DA0BF15B628B4 /* Secrets.example.plist */; };
 		C485A5E90C35443F32988330 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5A2E4F83C3B47FFC9939C469 /* Info.plist */; };
+		C550C146E7F66AC0C26C7CE5 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = FE197619BE346D8CE2D36B96 /* Secrets.plist */; };
+		CA82194884970E747FA97A14 /* MusicBrainzService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7414E9B734282F6B342C5A /* MusicBrainzService.swift */; };
+		CB9DE65E77A6A9920250F8D7 /* RadarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A647E4552F30A7374FDCC /* RadarChartView.swift */; };
 		CF56914916AA5B8CC433D86F /* CollageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7933EA834B896C87C1F7BA /* CollageViewModel.swift */; };
 		D71A9DB3E05F1807BE21160C /* MediaRemoteBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E507B8BC0D0152B1CB879A /* MediaRemoteBridge.swift */; };
+		D7E86D3F78C3042B40B90ED3 /* iTunesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB67D6E70719959ED127C567 /* iTunesService.swift */; };
 		D9643C658E5F4D823638ED9A /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD12B4CB16C74BEFCD7E7473 /* Track.swift */; };
 		DD135A1C4DAF72925830D6F7 /* MetricsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6052BE4C62C9BBD87485D /* MetricsService.swift */; };
 		DF35F5B9EE37C276DC9F5710 /* ScrobbleNowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C5EFF085D5F70BD16C3644 /* ScrobbleNowApp.swift */; };
 		E1FD89349690CCE755E3E772 /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1B44005A77903F50E51973 /* SparklineView.swift */; };
+		E708DFF4A228C1EC56DAC9EA /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD12B4CB16C74BEFCD7E7473 /* Track.swift */; };
+		E7C2C63B66C05D9DB2BEDB04 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C98113A7ABDD5E7BDF1F23 /* SettingsManager.swift */; };
 		F308F446FD29717A2B7D0B2C /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD2BD832C94BD88F4F7299 /* HistoryViewModel.swift */; };
+		F7CB61806C99C01FCB8E9861 /* NowPlayingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922EE3C3F67D7EA943FF2B4F /* NowPlayingViewModel.swift */; };
+		FE6EB7BCD3CB3413049A8DA6 /* CollageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7933EA834B896C87C1F7BA /* CollageViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -57,6 +96,7 @@
 		3EB4C530B436DAC304D43681 /* LastFMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastFMService.swift; sourceTree = "<group>"; };
 		402CDC8AE6CD24F04BFFC71B /* AlbumDiscoveryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDiscoveryService.swift; sourceTree = "<group>"; };
 		475214BADE0D94B22F53D601 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		4835A1860F5ACC8A6948705E /* ScrobbleNowiOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ScrobbleNowiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F96D950C7C4D1627BA1BDE8 /* ScrobbleNow.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ScrobbleNow.entitlements; sourceTree = "<group>"; };
 		4FC4A8F0FE421C4A49FDEFB0 /* APITracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITracker.swift; sourceTree = "<group>"; };
 		54BF1538A622E83C2C86506E /* YouTubeMusicFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeMusicFilter.swift; sourceTree = "<group>"; };
@@ -70,15 +110,19 @@
 		81A3650658D9721D4060B6A6 /* StatisticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewModel.swift; sourceTree = "<group>"; };
 		88F6052BE4C62C9BBD87485D /* MetricsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsService.swift; sourceTree = "<group>"; };
 		8CC0CBEE725DC8AF8080E89A /* AlbumDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailView.swift; sourceTree = "<group>"; };
+		8F0C55D55CA394E6FF2818F9 /* SystemNowPlaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNowPlaying.swift; sourceTree = "<group>"; };
 		922EE3C3F67D7EA943FF2B4F /* NowPlayingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingViewModel.swift; sourceTree = "<group>"; };
 		AB479C6E709FA48840511EBB /* CacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheService.swift; sourceTree = "<group>"; };
+		AD6CF26C04EC1F288F7BF407 /* MPNowPlayingBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPNowPlayingBridge.swift; sourceTree = "<group>"; };
 		BCB2BB2F20879D5AA4800774 /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
 		BF9BDB1C50EA86588165F202 /* ScrobbleCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrobbleCache.swift; sourceTree = "<group>"; };
+		C962FA640E5DCB09F0AA1FFA /* PlatformImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformImage.swift; sourceTree = "<group>"; };
 		D47FEFBAE226AF02FF9AB976 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		D8C98113A7ABDD5E7BDF1F23 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		DB67D6E70719959ED127C567 /* iTunesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iTunesService.swift; sourceTree = "<group>"; };
 		DB7414E9B734282F6B342C5A /* MusicBrainzService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicBrainzService.swift; sourceTree = "<group>"; };
 		E00961C407B21D13CF45EB9E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E95E4954D6A90905F67E61A2 /* ScrobbleNowiOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrobbleNowiOSApp.swift; sourceTree = "<group>"; };
 		F3A424FB0DA92E827E33FDB9 /* CollageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollageView.swift; sourceTree = "<group>"; };
 		F4FE681000BC36994A602D83 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		F556D31BB2BA17C92DBE8A80 /* WikidataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikidataService.swift; sourceTree = "<group>"; };
@@ -89,6 +133,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
+		15F92CD74F6AABC86282D8FD /* ScrobbleNowiOS */ = {
+			isa = PBXGroup;
+			children = (
+				AD6CF26C04EC1F288F7BF407 /* MPNowPlayingBridge.swift */,
+				E95E4954D6A90905F67E61A2 /* ScrobbleNowiOSApp.swift */,
+			);
+			path = ScrobbleNowiOS;
+			sourceTree = "<group>";
+		};
 		1F1B0658793DE120569C0A07 /* ScrobbleNow */ = {
 			isa = PBXGroup;
 			children = (
@@ -96,6 +149,7 @@
 				536664214AD2BBA5A9CCA5C6 /* Models */,
 				61E4B43FB6CEDC51079FF09C /* Resources */,
 				F1141E265F02D77F30DBE1BB /* Services */,
+				3DFA6566359A02711AFDEB82 /* Shared */,
 				2B6312A219BE34E5C8EDE217 /* Views */,
 			);
 			path = ScrobbleNow;
@@ -118,6 +172,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		3DFA6566359A02711AFDEB82 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				C962FA640E5DCB09F0AA1FFA /* PlatformImage.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
 		536664214AD2BBA5A9CCA5C6 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -128,6 +190,7 @@
 				922EE3C3F67D7EA943FF2B4F /* NowPlayingViewModel.swift */,
 				D8C98113A7ABDD5E7BDF1F23 /* SettingsManager.swift */,
 				81A3650658D9721D4060B6A6 /* StatisticsViewModel.swift */,
+				8F0C55D55CA394E6FF2818F9 /* SystemNowPlaying.swift */,
 				FD12B4CB16C74BEFCD7E7473 /* Track.swift */,
 			);
 			path = Models;
@@ -149,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				1F1B0658793DE120569C0A07 /* ScrobbleNow */,
+				15F92CD74F6AABC86282D8FD /* ScrobbleNowiOS */,
 				BB00A2E5D0BEC7BD2220E4D7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -157,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				2D9FC698960908EA651FD429 /* ScrobbleNow.app */,
+				4835A1860F5ACC8A6948705E /* ScrobbleNowiOS.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -211,6 +276,24 @@
 			productReference = 2D9FC698960908EA651FD429 /* ScrobbleNow.app */;
 			productType = "com.apple.product-type.application";
 		};
+		C68E352C9E065EEB55AD4D25 /* ScrobbleNowiOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1DFF934CDA838832CCC16847 /* Build configuration list for PBXNativeTarget "ScrobbleNowiOS" */;
+			buildPhases = (
+				428653419688A2CEA639DDC3 /* Sources */,
+				22CBC74725C6440D2F95CBBB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ScrobbleNowiOS;
+			packageProductDependencies = (
+			);
+			productName = ScrobbleNowiOS;
+			productReference = 4835A1860F5ACC8A6948705E /* ScrobbleNowiOS.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -221,6 +304,10 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					BAF763319D7C797101653D7A = {
+						DevelopmentTeam = YNB3ADRMFC;
+						ProvisioningStyle = Automatic;
+					};
+					C68E352C9E065EEB55AD4D25 = {
 						DevelopmentTeam = YNB3ADRMFC;
 						ProvisioningStyle = Automatic;
 					};
@@ -241,6 +328,7 @@
 			projectRoot = "";
 			targets = (
 				BAF763319D7C797101653D7A /* ScrobbleNow */,
+				C68E352C9E065EEB55AD4D25 /* ScrobbleNowiOS */,
 			);
 		};
 /* End PBXProject section */
@@ -257,9 +345,60 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		22CBC74725C6440D2F95CBBB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				63C5793D3E0BCDBE450F898E /* Assets.xcassets in Resources */,
+				B5172DDDFBE9FD9323CBEB54 /* Secrets.example.plist in Resources */,
+				C550C146E7F66AC0C26C7CE5 /* Secrets.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		428653419688A2CEA639DDC3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				23C99D34F4E5D7E56D55A258 /* APITracker.swift in Sources */,
+				A7A3A8106E40084102DE1EE1 /* AccentColor.swift in Sources */,
+				752BE5B3D2722A9D1A68EF13 /* Album.swift in Sources */,
+				04631386DFDB792CA8ED03F8 /* AlbumDetailView.swift in Sources */,
+				95C52601CE30BA78852058F8 /* AlbumDiscoveryService.swift in Sources */,
+				2D8CF4034D649388E7205462 /* CacheService.swift in Sources */,
+				B31F0CA9754B15949A380E5D /* CollageView.swift in Sources */,
+				FE6EB7BCD3CB3413049A8DA6 /* CollageViewModel.swift in Sources */,
+				794BF6F6EB95B2631952669F /* DiscogsService.swift in Sources */,
+				A4B345FC24488FDF1EB2DDCA /* HistoryView.swift in Sources */,
+				98B24A70524A5C518EF27421 /* HistoryViewModel.swift in Sources */,
+				1E5216179E621B10E341322D /* KeychainService.swift in Sources */,
+				8582B339081DFE55C0230AB7 /* LastFMService.swift in Sources */,
+				72211E1C53163C98A5AC00C9 /* LibraryView.swift in Sources */,
+				2465A17A25A6A8B16E2DBEEA /* LibraryViewModel.swift in Sources */,
+				6E256F60E0DA83541A6ACBC0 /* MPNowPlayingBridge.swift in Sources */,
+				CA82194884970E747FA97A14 /* MusicBrainzService.swift in Sources */,
+				060E5C068DD007D897484F5C /* NowPlayingView.swift in Sources */,
+				F7CB61806C99C01FCB8E9861 /* NowPlayingViewModel.swift in Sources */,
+				699BE5E7825946678B4120EE /* PlatformImage.swift in Sources */,
+				CB9DE65E77A6A9920250F8D7 /* RadarChartView.swift in Sources */,
+				26EF427488E4AB61974433F2 /* ScrobbleCache.swift in Sources */,
+				13F5C76719408C9115951E92 /* ScrobbleNowiOSApp.swift in Sources */,
+				E7C2C63B66C05D9DB2BEDB04 /* SettingsManager.swift in Sources */,
+				A06110905BCE6E1233B27F1A /* SettingsView.swift in Sources */,
+				0CA23012ECB19020988FF852 /* SparklineView.swift in Sources */,
+				3EE44B8CD0CE384793B91F81 /* StatisticsView.swift in Sources */,
+				8F37E48851B0BC2B29ED1BD4 /* StatisticsViewModel.swift in Sources */,
+				7AC847C1CC26873D42E13F78 /* SystemNowPlaying.swift in Sources */,
+				2D2B5386EB0355DB8D1D2DA7 /* SystemScrobbleService.swift in Sources */,
+				E708DFF4A228C1EC56DAC9EA /* Track.swift in Sources */,
+				25D07AA16642575B11FCD564 /* WikidataService.swift in Sources */,
+				226B44F05BC44BCC453E40A7 /* YouTubeMusicFilter.swift in Sources */,
+				D7E86D3F78C3042B40B90ED3 /* iTunesService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		605740C98EEDA1C50C1330AC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -284,6 +423,7 @@
 				0411D4BD98B0A692B918C738 /* MusicBrainzService.swift in Sources */,
 				42B1D520A0213B02A7650386 /* NowPlayingView.swift in Sources */,
 				19E221D7BD55284070245C6E /* NowPlayingViewModel.swift in Sources */,
+				182680E9969FE8ED7810258F /* PlatformImage.swift in Sources */,
 				34F13A0C91351C800524B842 /* RadarChartView.swift in Sources */,
 				76E9B67AC9C98FFCB28AAB01 /* ScrobbleCache.swift in Sources */,
 				DF35F5B9EE37C276DC9F5710 /* ScrobbleNowApp.swift in Sources */,
@@ -292,6 +432,7 @@
 				E1FD89349690CCE755E3E772 /* SparklineView.swift in Sources */,
 				78C6A2A7C4454084919B997E /* StatisticsView.swift in Sources */,
 				9AAB082D4C52B0BB2986EC91 /* StatisticsViewModel.swift in Sources */,
+				BDF75E9C680BDA459A81ABFF /* SystemNowPlaying.swift in Sources */,
 				838D457CB4833F9EA3B31F14 /* SystemScrobbleService.swift in Sources */,
 				D9643C658E5F4D823638ED9A /* Track.swift in Sources */,
 				6CFF6CD9103720A4B84760BA /* WikidataService.swift in Sources */,
@@ -318,6 +459,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.personal.ScrobbleNow;
 				PRODUCT_NAME = "Scrobble Now";
@@ -370,11 +512,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.9;
@@ -432,12 +574,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.9;
@@ -459,6 +601,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.personal.ScrobbleNow;
 				PRODUCT_NAME = "Scrobble Now";
@@ -466,9 +609,70 @@
 			};
 			name = Release;
 		};
+		AEBE07674E97B63AC379ABE3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YNB3ADRMFC;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				INFOPLIST_KEY_CFBundleDisplayName = "Scrobble Now";
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoads = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.personal.ScrobbleNow.ios;
+				PRODUCT_NAME = "Scrobble Now";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CF3BF25CFBCB33AA35FD0649 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YNB3ADRMFC;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				INFOPLIST_KEY_CFBundleDisplayName = "Scrobble Now";
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoads = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.personal.ScrobbleNow.ios;
+				PRODUCT_NAME = "Scrobble Now";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1DFF934CDA838832CCC16847 /* Build configuration list for PBXNativeTarget "ScrobbleNowiOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AEBE07674E97B63AC379ABE3 /* Debug */,
+				CF3BF25CFBCB33AA35FD0649 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		89A634862E8211D914149555 /* Build configuration list for PBXProject "ScrobbleNow" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ScrobbleNow/App/ScrobbleNowApp.swift
+++ b/ScrobbleNow/App/ScrobbleNowApp.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 
 @main
@@ -54,3 +55,4 @@ struct MenuBarLabel: View {
         }
     }
 }
+#endif

--- a/ScrobbleNow/Models/CollageViewModel.swift
+++ b/ScrobbleNow/Models/CollageViewModel.swift
@@ -1,4 +1,9 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#elseif os(iOS)
+import UIKit
+#endif
 
 struct GridSize: Equatable {
     let label: String
@@ -19,7 +24,7 @@ class CollageViewModel: ObservableObject {
     @Published var exportMessage: String?
 
     /// Pre-downloaded artwork keyed by URL string
-    private var downloadedImages: [String: NSImage] = [:]
+    private var downloadedImages: [String: PlatformImage] = [:]
 
     static let gridSizes: [GridSize] = [
         GridSize(label: "3×3", cols: 3, rows: 3),
@@ -50,7 +55,7 @@ class CollageViewModel: ObservableObject {
     }
 
     private func predownloadArtwork() async {
-        await withTaskGroup(of: (String, NSImage?).self) { group in
+        await withTaskGroup(of: (String, PlatformImage?).self) { group in
             for album in albums.prefix(gridSize.total) {
                 guard let url = album.artworkURL else { continue }
                 let key = url.absoluteString
@@ -59,7 +64,7 @@ class CollageViewModel: ObservableObject {
                 group.addTask {
                     do {
                         let (data, _) = try await URLSession.shared.data(from: url)
-                        return (key, NSImage(data: data))
+                        return (key, PlatformImage(data: data))
                     } catch {
                         return (key, nil)
                     }
@@ -74,6 +79,7 @@ class CollageViewModel: ObservableObject {
 
     // MARK: - Export as Image
 
+    #if os(macOS)
     func exportCollage() {
         guard let pngData = renderCollagePNG() else {
             exportMessage = "Render failed"
@@ -111,6 +117,28 @@ class CollageViewModel: ObservableObject {
             exportMessage = nil
         }
     }
+    #endif
+
+    #if os(iOS)
+    func shareCollage() -> Data? {
+        return renderCollagePNG()
+    }
+
+    func copyToClipboard() {
+        guard let pngData = renderCollagePNG(),
+              let image = UIImage(data: pngData) else {
+            exportMessage = "Render failed"
+            return
+        }
+
+        UIPasteboard.general.image = image
+        exportMessage = "Copied!"
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            exportMessage = nil
+        }
+    }
+    #endif
 
     // MARK: - Render to PNG Data
 
@@ -123,6 +151,7 @@ class CollageViewModel: ObservableObject {
 
         guard width > 0, height > 0 else { return nil }
 
+        #if os(macOS)
         let bitmap = NSBitmapImageRep(
             bitmapDataPlanes: nil,
             pixelsWide: width, pixelsHigh: height,
@@ -198,5 +227,68 @@ class CollageViewModel: ObservableObject {
         NSGraphicsContext.restoreGraphicsState()
 
         return bitmap.representation(using: .png, properties: [.compressionFactor: 0.9])
+
+        #elseif os(iOS)
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
+        let image = renderer.image { ctx in
+            // Black background
+            UIColor.black.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+            let subset = Array(albums.prefix(gridSize.total))
+            for (i, album) in subset.enumerated() {
+                let col = i % cols
+                let row = i / cols
+                let x = col * cellSize
+                let y = row * cellSize
+
+                let rect = CGRect(x: x, y: y, width: cellSize, height: cellSize)
+
+                // Use pre-downloaded image
+                if let artURL = album.artworkURL,
+                   let albumImage = downloadedImages[artURL.absoluteString] {
+                    albumImage.draw(in: rect)
+                } else {
+                    UIColor(white: 0.1, alpha: 1).setFill()
+                    ctx.fill(rect)
+
+                    // Draw initials
+                    let initials = String(album.albumName.prefix(2)).uppercased()
+                    let attrs: [NSAttributedString.Key: Any] = [
+                        .font: UIFont.boldSystemFont(ofSize: 24),
+                        .foregroundColor: UIColor(white: 0.3, alpha: 1),
+                    ]
+                    let str = NSAttributedString(string: initials, attributes: attrs)
+                    let strSize = str.size()
+                    str.draw(at: CGPoint(x: CGFloat(x) + (CGFloat(cellSize) - strSize.width) / 2,
+                                         y: CGFloat(y) + (CGFloat(cellSize) - strSize.height) / 2))
+                }
+
+                // Title overlay
+                if showTitles {
+                    let barHeight: CGFloat = 36
+                    let barRect = CGRect(x: x, y: y + cellSize - Int(barHeight), width: cellSize, height: Int(barHeight))
+                    UIColor(white: 0, alpha: 0.65).setFill()
+                    ctx.fill(barRect)
+
+                    let titleAttr: [NSAttributedString.Key: Any] = [
+                        .font: UIFont.systemFont(ofSize: 11, weight: .bold),
+                        .foregroundColor: UIColor.white,
+                    ]
+                    let artistAttr: [NSAttributedString.Key: Any] = [
+                        .font: UIFont.systemFont(ofSize: 9),
+                        .foregroundColor: UIColor(white: 1, alpha: 0.8),
+                    ]
+
+                    NSAttributedString(string: album.albumName, attributes: titleAttr)
+                        .draw(at: CGPoint(x: CGFloat(x) + 6, y: CGFloat(y + cellSize) - barHeight + 4))
+                    NSAttributedString(string: album.artistName, attributes: artistAttr)
+                        .draw(at: CGPoint(x: CGFloat(x) + 6, y: CGFloat(y + cellSize) - barHeight + 20))
+                }
+            }
+        }
+
+        return image.pngData()
+        #endif
     }
 }

--- a/ScrobbleNow/Models/NowPlayingViewModel.swift
+++ b/ScrobbleNow/Models/NowPlayingViewModel.swift
@@ -6,7 +6,7 @@ class NowPlayingViewModel: ObservableObject {
     @Published var recentTracks: [ScrobbledTrack] = []
     @Published var isLoading = false
     @Published var errorMessage: String?
-    @Published var albumArtwork: NSImage?
+    @Published var albumArtwork: PlatformImage?
 
     private let lastfmService = LastFMService()
     private let cache = CacheService.shared
@@ -46,7 +46,7 @@ class NowPlayingViewModel: ObservableObject {
             if let np = nowPlaying, np.name != oldNowPlaying?.name,
                let artURL = np.albumArtworkURL {
                 let (data, _) = try await URLSession.shared.data(from: artURL)
-                albumArtwork = NSImage(data: data)
+                albumArtwork = PlatformImage(data: data)
             }
 
             errorMessage = nil

--- a/ScrobbleNow/Models/SettingsManager.swift
+++ b/ScrobbleNow/Models/SettingsManager.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if os(macOS)
 import ServiceManagement
+#endif
 
 @MainActor
 class SettingsManager: ObservableObject {
@@ -37,7 +39,11 @@ class SettingsManager: ObservableObject {
         if !artworkDownloadPath.isEmpty, FileManager.default.fileExists(atPath: artworkDownloadPath) {
             return URL(fileURLWithPath: artworkDownloadPath)
         }
+        #if os(macOS)
         return FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
+        #else
+        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        #endif
     }
 
     // MARK: - Scrobble Behavior
@@ -50,6 +56,7 @@ class SettingsManager: ObservableObject {
     @AppStorage("scrobbleNotifications") var scrobbleNotifications: Bool = false
 
     // MARK: - System
+    #if os(macOS)
     @AppStorage("launchAtLogin") var launchAtLogin: Bool = false {
         didSet { updateLaunchAtLogin() }
     }
@@ -65,4 +72,5 @@ class SettingsManager: ObservableObject {
             print("Launch at login error: \(error)")
         }
     }
+    #endif
 }

--- a/ScrobbleNow/Models/SystemNowPlaying.swift
+++ b/ScrobbleNow/Models/SystemNowPlaying.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct SystemNowPlaying: Equatable {
+    let title: String
+    let artist: String
+    let album: String
+    let duration: Double
+    let elapsed: Double
+    let playbackRate: Double
+    let artwork: PlatformImage?
+    let sourceBundleId: String
+    let sourceAppName: String
+    let timestamp: Date
+
+    var isPlaying: Bool { playbackRate > 0 }
+    var progress: Double { duration > 0 ? min(1, elapsed / duration) : 0 }
+    var elapsedFormatted: String { formatTime(elapsed) }
+    var durationFormatted: String { formatTime(duration) }
+    var remainingFormatted: String { formatTime(max(0, duration - elapsed)) }
+
+    func withArtwork(_ img: PlatformImage) -> SystemNowPlaying {
+        SystemNowPlaying(title: title, artist: artist, album: album,
+                         duration: duration, elapsed: elapsed, playbackRate: playbackRate,
+                         artwork: img, sourceBundleId: sourceBundleId,
+                         sourceAppName: sourceAppName, timestamp: timestamp)
+    }
+
+    private func formatTime(_ seconds: Double) -> String {
+        let m = Int(seconds) / 60; let s = Int(seconds) % 60
+        return "\(m):\(String(format: "%02d", s))"
+    }
+
+    static func == (lhs: SystemNowPlaying, rhs: SystemNowPlaying) -> Bool {
+        lhs.title == rhs.title && lhs.artist == rhs.artist && lhs.sourceBundleId == rhs.sourceBundleId
+    }
+}

--- a/ScrobbleNow/Services/CacheService.swift
+++ b/ScrobbleNow/Services/CacheService.swift
@@ -1,10 +1,10 @@
-import AppKit
+import Foundation
 
 actor CacheService {
     static let shared = CacheService()
 
     private var albumCache: [String: AlbumDetail] = [:]
-    private var imageCache: [URL: NSImage] = [:]
+    private var imageCache: [URL: PlatformImage] = [:]
     private var recentTracksCache: [String: [ScrobbledTrack]] = [:]
 
     // MARK: - Albums
@@ -17,11 +17,11 @@ actor CacheService {
     }
 
     // MARK: - Images
-    func getCachedImage(url: URL) -> NSImage? {
+    func getCachedImage(url: URL) -> PlatformImage? {
         imageCache[url]
     }
 
-    func cacheImage(url: URL, image: NSImage) {
+    func cacheImage(url: URL, image: PlatformImage) {
         imageCache[url] = image
         if imageCache.count > 100 {
             let keysToRemove = Array(imageCache.keys.prefix(20))

--- a/ScrobbleNow/Services/MediaRemoteBridge.swift
+++ b/ScrobbleNow/Services/MediaRemoteBridge.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 import AppKit
 
@@ -335,7 +336,7 @@ class MediaRemoteBridge: ObservableObject {
                 }
                 // If YouTube Music API gave us artist/track, fetch proper album art from Last.fm
                 if let ytArtist = result.artist, let ytTrack = result.track {
-                    var artwork: NSImage?
+                    var artwork: PlatformImage?
                     var albumName = result.album ?? ""
 
                     // Try Last.fm track.getInfo for album art
@@ -362,7 +363,7 @@ class MediaRemoteBridge: ObservableObject {
                                            let urlStr = img["#text"] as? String, !urlStr.isEmpty,
                                            let imgURL = URL(string: urlStr),
                                            let (imgData, _) = try? await URLSession.shared.data(from: imgURL) {
-                                            artwork = NSImage(data: imgData)
+                                            artwork = PlatformImage(data: imgData)
                                             break
                                         }
                                     }
@@ -375,7 +376,7 @@ class MediaRemoteBridge: ObservableObject {
                     if artwork == nil {
                         let thumbURL = URL(string: "https://img.youtube.com/vi/\(videoId)/hqdefault.jpg")!
                         if let (imgData, _) = try? await URLSession.shared.data(from: thumbURL) {
-                            artwork = NSImage(data: imgData)
+                            artwork = PlatformImage(data: imgData)
                         }
                     }
 
@@ -570,9 +571,9 @@ class MediaRemoteBridge: ObservableObject {
             }
         }
 
-        var artwork: NSImage?
+        var artwork: PlatformImage?
         if let data = info["kMRMediaRemoteNowPlayingInfoArtworkData"] as? Data, !data.isEmpty {
-            artwork = NSImage(data: data)
+            artwork = PlatformImage(data: data)
         }
 
         let track = SystemNowPlaying(
@@ -639,7 +640,7 @@ class MediaRemoteBridge: ObservableObject {
 
     // MARK: - Spotify Artwork
 
-    private func loadSpotifyArtwork() async -> NSImage? {
+    private func loadSpotifyArtwork() async -> PlatformImage? {
         let script = """
         tell application "Spotify"
             if player state is playing then
@@ -652,7 +653,7 @@ class MediaRemoteBridge: ObservableObject {
         let result = appleScript.executeAndReturnError(&error)
         guard error == nil, let urlStr = result.stringValue, let url = URL(string: urlStr),
               let (data, _) = try? await URLSession.shared.data(from: url) else { return nil }
-        return NSImage(data: data)
+        return PlatformImage(data: data)
     }
 
     // MARK: - Helpers
@@ -675,40 +676,4 @@ class MediaRemoteBridge: ObservableObject {
 
     deinit { if let handle { dlclose(handle) } }
 }
-
-// MARK: - Data Model
-
-struct SystemNowPlaying: Equatable {
-    let title: String
-    let artist: String
-    let album: String
-    let duration: Double
-    let elapsed: Double
-    let playbackRate: Double
-    let artwork: NSImage?
-    let sourceBundleId: String
-    let sourceAppName: String
-    let timestamp: Date
-
-    var isPlaying: Bool { playbackRate > 0 }
-    var progress: Double { duration > 0 ? min(1, elapsed / duration) : 0 }
-    var elapsedFormatted: String { formatTime(elapsed) }
-    var durationFormatted: String { formatTime(duration) }
-    var remainingFormatted: String { formatTime(max(0, duration - elapsed)) }
-
-    func withArtwork(_ img: NSImage) -> SystemNowPlaying {
-        SystemNowPlaying(title: title, artist: artist, album: album,
-                         duration: duration, elapsed: elapsed, playbackRate: playbackRate,
-                         artwork: img, sourceBundleId: sourceBundleId,
-                         sourceAppName: sourceAppName, timestamp: timestamp)
-    }
-
-    private func formatTime(_ seconds: Double) -> String {
-        let m = Int(seconds) / 60; let s = Int(seconds) % 60
-        return "\(m):\(String(format: "%02d", s))"
-    }
-
-    static func == (lhs: SystemNowPlaying, rhs: SystemNowPlaying) -> Bool {
-        lhs.title == rhs.title && lhs.artist == rhs.artist && lhs.sourceBundleId == rhs.sourceBundleId
-    }
-}
+#endif

--- a/ScrobbleNow/Services/MetricsService.swift
+++ b/ScrobbleNow/Services/MetricsService.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 import AppKit
 
@@ -195,3 +196,4 @@ class MetricsService: ObservableObject {
         String(format: "%.2fs", cpuTimeSec)
     }
 }
+#endif

--- a/ScrobbleNow/Services/SystemScrobbleService.swift
+++ b/ScrobbleNow/Services/SystemScrobbleService.swift
@@ -18,7 +18,11 @@ class SystemScrobbleService: ObservableObject {
 
     // MARK: - Dependencies
 
+    #if os(macOS)
     private let bridge = MediaRemoteBridge.shared
+    #elseif os(iOS)
+    private let bridge = MPNowPlayingBridge.shared
+    #endif
     private let lastfm = LastFMService()
     private var settings: SettingsManager { SettingsManager.shared }
 
@@ -178,7 +182,9 @@ class SystemScrobbleService: ObservableObject {
         }
 
         // Also refresh the bridge data periodically for elapsed time updates
+        #if os(macOS)
         bridge.pollMediaRemote()
+        #endif
     }
 
     // MARK: - Retry Timer
@@ -235,7 +241,7 @@ class SystemScrobbleService: ObservableObject {
                        let urlStr = img["#text"] as? String, !urlStr.isEmpty,
                        let url = URL(string: urlStr) {
                         let (data, _) = try await URLSession.shared.data(from: url)
-                        if let image = NSImage(data: data) {
+                        if let image = PlatformImage(data: data) {
                             // Update the track in the bridge with artwork
                             let updated = track.withArtwork(image)
                             bridge.activeSources[track.sourceBundleId] = updated
@@ -261,7 +267,7 @@ class SystemScrobbleService: ObservableObject {
                        let urlStr = img["#text"] as? String, !urlStr.isEmpty,
                        let url = URL(string: urlStr) {
                         let (data, _) = try await URLSession.shared.data(from: url)
-                        if let image = NSImage(data: data) {
+                        if let image = PlatformImage(data: data) {
                             let updated = track.withArtwork(image)
                             bridge.activeSources[track.sourceBundleId] = updated
                             if bridge.currentTrack?.sourceBundleId == track.sourceBundleId {
@@ -279,18 +285,11 @@ class SystemScrobbleService: ObservableObject {
 
         // Fallback: YouTube thumbnail if it's a YouTube source
         if track.sourceBundleId == "com.google.Chrome" || track.sourceAppName.contains("YouTube") {
-            // Extract video ID from the browser's last known URL and use YouTube thumbnail
             await fetchYouTubeThumbnail(for: track)
         }
     }
 
     private func fetchYouTubeThumbnail(for track: SystemNowPlaying) async {
-        // Use the YouTube Music API to get thumbnail — we need the video ID
-        // Search by title + artist to find it
-        let query = "\(track.artist) \(track.title)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        // Try the high-quality thumbnail via YouTube oEmbed
-        let oembedURL = URL(string: "https://www.youtube.com/oembed?url=https://www.youtube.com/results?search_query=\(query)&format=json")
-
         // Simpler: use Last.fm artist image as fallback
         let artistURL = URL(string: "https://ws.audioscrobbler.com/2.0/?method=artist.getInfo&api_key=\(KeychainService.lastfmApiKey)&artist=\(track.artist.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&format=json")!
 
@@ -304,7 +303,7 @@ class SystemScrobbleService: ObservableObject {
                        let urlStr = img["#text"] as? String, !urlStr.isEmpty,
                        let url = URL(string: urlStr) {
                         let (imgData, _) = try await URLSession.shared.data(from: url)
-                        if let image = NSImage(data: imgData) {
+                        if let image = PlatformImage(data: imgData) {
                             let updated = track.withArtwork(image)
                             bridge.activeSources[track.sourceBundleId] = updated
                             if bridge.currentTrack?.sourceBundleId == track.sourceBundleId {
@@ -319,13 +318,11 @@ class SystemScrobbleService: ObservableObject {
         } catch {}
 
         // Last resort: YouTube video thumbnail directly
-        // Most YouTube video IDs are in the sourceAppName from the filter
-        // Use a generic high-quality thumbnail pattern
         if let videoId = findCurrentYouTubeVideoId() {
             let thumbURL = URL(string: "https://img.youtube.com/vi/\(videoId)/hqdefault.jpg")!
             do {
                 let (data, _) = try await URLSession.shared.data(from: thumbURL)
-                if let image = NSImage(data: data) {
+                if let image = PlatformImage(data: data) {
                     let updated = track.withArtwork(image)
                     bridge.activeSources[track.sourceBundleId] = updated
                     if bridge.currentTrack?.sourceBundleId == track.sourceBundleId {
@@ -338,11 +335,15 @@ class SystemScrobbleService: ObservableObject {
     }
 
     private func findCurrentYouTubeVideoId() -> String? {
+        #if os(macOS)
         // Check the last browser title key for a YouTube URL
         let lastTitle = bridge.lastBrowserTitle
         // The bridge stores "bundleId:title" — we need to find the URL from the last poll
         // For now, return nil — we'll improve this later
         return nil
+        #else
+        return nil
+        #endif
     }
 
     // MARK: - Scrobble Submission

--- a/ScrobbleNow/Shared/PlatformImage.swift
+++ b/ScrobbleNow/Shared/PlatformImage.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+typealias PlatformImage = NSImage
+#elseif os(iOS)
+import UIKit
+typealias PlatformImage = UIImage
+#endif
+
+extension PlatformImage {
+    var swiftUIImage: Image {
+        #if os(macOS)
+        Image(nsImage: self)
+        #else
+        Image(uiImage: self)
+        #endif
+    }
+}

--- a/ScrobbleNow/Views/AlbumDetailView.swift
+++ b/ScrobbleNow/Views/AlbumDetailView.swift
@@ -426,7 +426,11 @@ struct AlbumDetailView: View {
 
     private func linkButton(label: String, color: Color, url: URL) -> some View {
         Button {
+            #if os(macOS)
             NSWorkspace.shared.open(url)
+            #else
+            UIApplication.shared.open(url)
+            #endif
         } label: {
             Text(label)
                 .font(.system(size: 8, weight: .medium))

--- a/ScrobbleNow/Views/CollageView.swift
+++ b/ScrobbleNow/Views/CollageView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct CollageView: View {
     @StateObject private var vm = CollageViewModel()
+    #if os(iOS)
+    @State private var collageShareImage: Image?
+    @State private var showShareSheet = false
+    #endif
 
     var body: some View {
         VStack(spacing: 6) {
@@ -63,7 +67,9 @@ struct CollageView: View {
                     .padding(.vertical, 3)
                     .background(Color.white.opacity(0.05), in: Capsule())
                 }
+                #if os(macOS)
                 .menuStyle(.borderlessButton)
+                #endif
                 .fixedSize()
             }
             .padding(.horizontal, 16)
@@ -92,6 +98,7 @@ struct CollageView: View {
 
                 // Export button
                 HStack(spacing: 8) {
+                    #if os(macOS)
                     Button {
                         vm.exportCollage()
                     } label: {
@@ -107,6 +114,26 @@ struct CollageView: View {
                         .background(AppAccent.current.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
                     }
                     .buttonStyle(.plain)
+                    #else
+                    Button {
+                        if let data = vm.shareCollage(), let image = UIImage(data: data) {
+                            collageShareImage = Image(uiImage: image)
+                            showShareSheet = true
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "square.and.arrow.up")
+                                .font(.system(size: 9))
+                            Text("Share")
+                                .font(.system(size: 9, weight: .medium))
+                        }
+                        .foregroundStyle(AppAccent.current)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(AppAccent.current.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
+                    }
+                    .buttonStyle(.plain)
+                    #endif
 
                     Button {
                         vm.copyToClipboard()
@@ -143,6 +170,13 @@ struct CollageView: View {
 
             Spacer(minLength: 4)
         }
+        #if os(iOS)
+        .sheet(isPresented: $showShareSheet) {
+            if let image = collageShareImage {
+                ShareLink(item: image, preview: SharePreview("Scrobble Collage", image: image))
+            }
+        }
+        #endif
     }
 
     // MARK: - Collage Grid

--- a/ScrobbleNow/Views/NowPlayingView.swift
+++ b/ScrobbleNow/Views/NowPlayingView.swift
@@ -11,69 +11,33 @@ struct NowPlayingView: View {
     @State private var mode: AppMode = .feed
     @State private var albumToView: (name: String, artist: String)?
     @State private var isExpanded: Bool = false
+    @State private var lastNowPlaying: ScrobbledTrack?
+
+    #if os(macOS)
+    private var bridge: MediaRemoteBridge { MediaRemoteBridge.shared }
+    #else
+    private var bridge: MPNowPlayingBridge { MPNowPlayingBridge.shared }
+    #endif
 
     var body: some View {
         ZStack {
+            #if os(macOS)
             VisualEffectBackground()
+            #else
+            Color(.systemBackground).ignoresSafeArea()
+            #endif
 
             VStack(spacing: 0) {
                 // Top bar
                 HStack(spacing: 8) {
                     // Library
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            mode = mode == .library ? .feed : .library
-                            albumToView = nil
-                        }
-                    } label: {
-                        Image(systemName: "square.stack")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(mode == .library ? AppAccent.current : .secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Library")
-
+                    navButton(icon: "square.stack", mode: .library, label: "Library")
                     // Collage
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            mode = mode == .collage ? .feed : .collage
-                            albumToView = nil
-                        }
-                    } label: {
-                        Image(systemName: "square.grid.3x3")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(mode == .collage ? AppAccent.current : .secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Collage Generator")
-
+                    navButton(icon: "square.grid.3x3", mode: .collage, label: "Collage Generator")
                     // History
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            mode = mode == .history ? .feed : .history
-                            albumToView = nil
-                        }
-                    } label: {
-                        Image(systemName: "clock.arrow.circlepath")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(mode == .history ? AppAccent.current : .secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Listening History")
-
+                    navButton(icon: "clock.arrow.circlepath", mode: .history, label: "Listening History")
                     // Stats
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            mode = mode == .stats ? .feed : .stats
-                            albumToView = nil
-                        }
-                    } label: {
-                        Image(systemName: "chart.bar")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(mode == .stats ? AppAccent.current : .secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Statistics")
+                    navButton(icon: "chart.bar", mode: .stats, label: "Statistics")
 
                     Spacer()
 
@@ -89,7 +53,9 @@ struct NowPlayingView: View {
                             .foregroundStyle(mode == .settings ? AppAccent.current : .secondary)
                     }
                     .buttonStyle(.plain)
+                    #if os(macOS)
                     .help("Settings")
+                    #endif
                 }
                 .padding(.horizontal, 14)
                 .padding(.top, 8)
@@ -156,16 +122,14 @@ struct NowPlayingView: View {
                 .padding(.bottom, 8)
 
                 // ALL active playing sources
-                let playingSources = MediaRemoteBridge.shared.activeSources.values
+                let playingSources = bridge.activeSources.values
                     .filter { $0.isPlaying }
                     .sorted { $0.timestamp > $1.timestamp }
 
                 if let primary = playingSources.first {
                     if isExpanded {
-                        // ═══════ EXPANDED: one source in focus ═══════
                         expandedNowPlaying(track: primary, allSources: Array(playingSources))
                     } else {
-                        // ═══════ COMPACT: primary card ═══════
                         systemNowPlayingCard(track: primary)
                             .padding(.horizontal, 16)
                             .padding(.bottom, 4)
@@ -176,18 +140,31 @@ struct NowPlayingView: View {
                             }
                     }
 
-                    // ═══════ OTHER SOURCES: horizontal ticker strip ═══════
                     if playingSources.count > 1 {
                         otherSourcesStrip(
                             sources: Array(playingSources.dropFirst()),
                             onSelect: { selected in
-                                // Swap: make this the primary
-                                MediaRemoteBridge.shared.currentTrack = selected
+                                bridge.currentTrack = selected
                                 withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                                     isExpanded = true
                                 }
                             }
                         )
+                    }
+                } else if let np = viewModel.nowPlaying ?? (isExpanded ? lastNowPlaying : nil) {
+                    // Fallback: show Last.fm now-playing (cloud scrobble detection)
+                    if isExpanded {
+                        expandedLastFMNowPlaying(track: np)
+                    } else {
+                        nowPlayingCard(track: np)
+                            .padding(.horizontal, 16)
+                            .padding(.bottom, 4)
+                            .onTapGesture {
+                                lastNowPlaying = np
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                    isExpanded = true
+                                }
+                            }
                     }
                 }
 
@@ -243,6 +220,25 @@ struct NowPlayingView: View {
         }
     }
 
+    // MARK: - Nav Button Helper
+
+    private func navButton(icon: String, mode targetMode: AppMode, label: String) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                mode = mode == targetMode ? .feed : targetMode
+                albumToView = nil
+            }
+        } label: {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(mode == targetMode ? AppAccent.current : .secondary)
+        }
+        .buttonStyle(.plain)
+        #if os(macOS)
+        .help(label)
+        #endif
+    }
+
     // MARK: - Other Sources Horizontal Strip
 
     private func otherSourcesStrip(sources: [SystemNowPlaying], onSelect: @escaping (SystemNowPlaying) -> Void) -> some View {
@@ -273,7 +269,7 @@ struct NowPlayingView: View {
         HStack(spacing: 6) {
             // Small artwork
             if let artwork = source.artwork {
-                Image(nsImage: artwork)
+                artwork.swiftUIImage
                     .resizable()
                     .aspectRatio(1, contentMode: .fill)
                     .frame(width: 28, height: 28)
@@ -294,12 +290,14 @@ struct NowPlayingView: View {
                     .font(.system(size: 8, weight: .medium))
                     .lineLimit(1)
                 HStack(spacing: 3) {
+                    #if os(macOS)
                     if let icon = MediaRemoteBridge.shared.appIcon(for: source.sourceBundleId) {
                         Image(nsImage: icon)
                             .resizable()
                             .frame(width: 8, height: 8)
                             .clipShape(RoundedRectangle(cornerRadius: 1))
                     }
+                    #endif
                     Text(source.artist)
                         .font(.system(size: 7))
                         .foregroundStyle(.secondary)
@@ -344,7 +342,7 @@ struct NowPlayingView: View {
             // Large album artwork
             Group {
                 if let artwork = track.artwork {
-                    Image(nsImage: artwork)
+                    artwork.swiftUIImage
                         .resizable()
                         .aspectRatio(1, contentMode: .fill)
                 } else {
@@ -357,7 +355,11 @@ struct NowPlayingView: View {
                         }
                 }
             }
+            #if os(macOS)
             .frame(width: 240, height: 240)
+            #else
+            .frame(width: 300, height: 300)
+            #endif
             .clipShape(RoundedRectangle(cornerRadius: 16))
             .shadow(color: .black.opacity(0.3), radius: 20, y: 10)
             .padding(.bottom, 14)
@@ -421,12 +423,14 @@ struct NowPlayingView: View {
             HStack(spacing: 8) {
                 // Source app
                 HStack(spacing: 4) {
+                    #if os(macOS)
                     if let icon = MediaRemoteBridge.shared.appIcon(for: track.sourceBundleId) {
                         Image(nsImage: icon)
                             .resizable()
                             .frame(width: 12, height: 12)
                             .clipShape(RoundedRectangle(cornerRadius: 2))
                     }
+                    #endif
                     Text(track.sourceAppName)
                         .font(.system(size: 8, weight: .medium))
                         .foregroundStyle(.tertiary)
@@ -501,6 +505,112 @@ struct NowPlayingView: View {
         .buttonStyle(.plain)
     }
 
+    // MARK: - Expanded Last.fm Now Playing (cloud scrobble)
+
+    private func expandedLastFMNowPlaying(track: ScrobbledTrack) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Spacer()
+                Button {
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                        isExpanded = false
+                        lastNowPlaying = nil
+                    }
+                } label: {
+                    Image(systemName: "chevron.compact.down")
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 40, height: 20)
+                }
+                .buttonStyle(.plain)
+                Spacer()
+            }
+            .padding(.bottom, 4)
+
+            // Large album artwork
+            Group {
+                if let artURL = track.albumArtworkURL {
+                    AsyncImage(url: artURL) { phase in
+                        if case .success(let img) = phase {
+                            img.resizable().aspectRatio(1, contentMode: .fill)
+                        } else {
+                            RoundedRectangle(cornerRadius: 16)
+                                .fill(.ultraThinMaterial)
+                                .overlay {
+                                    Image(systemName: "music.note")
+                                        .font(.system(size: 36))
+                                        .foregroundStyle(.tertiary)
+                                }
+                        }
+                    }
+                } else {
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(.ultraThinMaterial)
+                        .overlay {
+                            Image(systemName: "music.note")
+                                .font(.system(size: 36))
+                                .foregroundStyle(.tertiary)
+                        }
+                }
+            }
+            #if os(macOS)
+            .frame(width: 240, height: 240)
+            #else
+            .frame(width: 300, height: 300)
+            #endif
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .shadow(color: .black.opacity(0.3), radius: 20, y: 10)
+            .padding(.bottom, 14)
+
+            Text(track.name)
+                .font(.system(size: 16, weight: .bold))
+                .lineLimit(1)
+                .padding(.horizontal, 20)
+
+            Text(track.artistName)
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .padding(.top, 2)
+
+            if !track.albumName.isEmpty {
+                Text(track.albumName)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .padding(.top, 1)
+            }
+
+            // Source badge
+            HStack(spacing: 4) {
+                Circle().fill(AppAccent.current).frame(width: 5, height: 5)
+                Text("SCROBBLING VIA LAST.FM")
+                    .font(.system(size: 7, weight: .bold, design: .monospaced))
+                    .foregroundStyle(AppAccent.current)
+            }
+            .padding(.top, 10)
+
+            // Action buttons
+            HStack(spacing: 12) {
+                expandedButton(icon: "heart", label: "Love") {
+                    // TODO: Love track on Last.fm
+                }
+                expandedButton(icon: "magnifyingglass", label: "Discover") {
+                    guard !track.artistName.isEmpty else { return }
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        albumToView = (track.albumName.isEmpty ? track.name : track.albumName, track.artistName)
+                        isExpanded = false
+                    }
+                }
+            }
+            .padding(.top, 12)
+            .padding(.horizontal, 20)
+
+            Spacer(minLength: 6)
+        }
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+
     // MARK: - System Now Playing Card (from MediaRemote)
 
     private func systemNowPlayingCard(track: SystemNowPlaying) -> some View {
@@ -508,7 +618,7 @@ struct NowPlayingView: View {
             HStack(spacing: 10) {
                 // System artwork
                 if let artwork = track.artwork {
-                    Image(nsImage: artwork)
+                    artwork.swiftUIImage
                         .resizable()
                         .aspectRatio(1, contentMode: .fill)
                         .frame(width: 56, height: 56)
@@ -526,12 +636,14 @@ struct NowPlayingView: View {
                 VStack(alignment: .leading, spacing: 3) {
                     // Source app badge
                     HStack(spacing: 4) {
+                        #if os(macOS)
                         if let icon = MediaRemoteBridge.shared.appIcon(for: track.sourceBundleId) {
                             Image(nsImage: icon)
                                 .resizable()
                                 .frame(width: 10, height: 10)
                                 .clipShape(RoundedRectangle(cornerRadius: 2))
                         }
+                        #endif
                         Text(track.sourceAppName.uppercased())
                             .font(.system(size: 7, weight: .bold, design: .monospaced))
                             .foregroundStyle(.secondary)
@@ -622,7 +734,7 @@ struct NowPlayingView: View {
         HStack(spacing: 10) {
             // Album art
             if let artwork = viewModel.albumArtwork {
-                Image(nsImage: artwork)
+                artwork.swiftUIImage
                     .resizable()
                     .aspectRatio(1, contentMode: .fill)
                     .frame(width: 56, height: 56)
@@ -720,6 +832,7 @@ struct NowPlayingView: View {
 
 // MARK: - Visual Effect Background
 
+#if os(macOS)
 struct VisualEffectBackground: NSViewRepresentable {
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
@@ -731,3 +844,4 @@ struct VisualEffectBackground: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
 }
+#endif

--- a/ScrobbleNow/Views/SettingsView.swift
+++ b/ScrobbleNow/Views/SettingsView.swift
@@ -83,6 +83,7 @@ struct SettingsView: View {
             // Downloads
             sectionHeader("Downloads")
 
+            #if os(macOS)
             HStack {
                 Text("Save artwork to")
                     .font(.system(size: 10))
@@ -111,12 +112,15 @@ struct SettingsView: View {
                 }
                 .buttonStyle(.plain)
             }
+            #endif
 
             Divider().opacity(0.2)
 
             // Appearance
             sectionHeader("Appearance")
+            #if os(macOS)
             settingsToggle("Show track in menu bar", isOn: $settings.showTitleInMenuBar)
+            #endif
 
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 5), spacing: 4) {
                 ForEach(AppAccent.options) { option in
@@ -139,6 +143,7 @@ struct SettingsView: View {
 
             Spacer(minLength: 8)
 
+            #if os(macOS)
             // Quit
             HStack {
                 Spacer()
@@ -150,6 +155,7 @@ struct SettingsView: View {
                 .foregroundStyle(.red)
                 Spacer()
             }
+            #endif
         }
     }
 
@@ -179,6 +185,7 @@ struct SettingsView: View {
             } else {
                 ForEach(SystemScrobbleService.shared.connectors) { connector in
                     HStack(spacing: 8) {
+                        #if os(macOS)
                         if let icon = MediaRemoteBridge.shared.appIcon(for: connector.bundleId) {
                             Image(nsImage: icon)
                                 .resizable()
@@ -189,6 +196,11 @@ struct SettingsView: View {
                                 .fill(.quaternary)
                                 .frame(width: 20, height: 20)
                         }
+                        #else
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(.quaternary)
+                            .frame(width: 20, height: 20)
+                        #endif
                         VStack(alignment: .leading, spacing: 1) {
                             Text(connector.displayName)
                                 .font(.system(size: 10, weight: .medium))
@@ -270,7 +282,9 @@ struct SettingsView: View {
     // MARK: - Developer Tab
     // ═══════════════════════════════════════════
 
+    #if os(macOS)
     @StateObject private var metrics = MetricsService.shared
+    #endif
 
     private var developerTab: some View {
         Group {
@@ -436,6 +450,7 @@ struct SettingsView: View {
 
             Divider().opacity(0.2)
 
+            #if os(macOS)
             // ═══════ App Metrics ═══════
             sectionHeader("App Metrics")
 
@@ -483,6 +498,15 @@ struct SettingsView: View {
                 diagRow("CPU Time", value: metrics.cpuTimeFormatted)
                 diagRow("Threads", value: "\(metrics.threadCount)")
             }
+            #else
+            // ═══════ Diagnostics (iOS) ═══════
+            sectionHeader("Diagnostics")
+
+            VStack(alignment: .leading, spacing: 3) {
+                diagRow("Connectors", value: "\(SystemScrobbleService.shared.connectors.count)")
+                diagRow("Last.fm session", value: KeychainService.lastfmSessionKey != nil ? "● Active" : "○ None")
+            }
+            #endif
 
             Divider().opacity(0.2)
 
@@ -560,6 +584,7 @@ struct SettingsView: View {
         }
     }
 
+    #if os(macOS)
     private func metricGauge(label: String, value: Double, unit: String, max: Double, color: Color) -> some View {
         VStack(spacing: 3) {
             ZStack {
@@ -587,6 +612,7 @@ struct SettingsView: View {
         }
         .frame(maxWidth: .infinity)
     }
+    #endif
 
     private func diagRow(_ label: String, value: String) -> some View {
         HStack {
@@ -723,7 +749,13 @@ struct SettingsView: View {
         do {
             let token = try await lastfmService.getAuthToken()
             let authURL = await lastfmService.authURL + "&token=\(token)"
-            if let url = URL(string: authURL) { NSWorkspace.shared.open(url) }
+            if let url = URL(string: authURL) {
+                #if os(macOS)
+                NSWorkspace.shared.open(url)
+                #else
+                await UIApplication.shared.open(url)
+                #endif
+            }
             try await Task.sleep(for: .seconds(15))
             let (sessionKey, username) = try await lastfmService.getSession(token: token)
             KeychainService.set(.lastfmSessionKey, value: sessionKey)

--- a/ScrobbleNowiOS/MPNowPlayingBridge.swift
+++ b/ScrobbleNowiOS/MPNowPlayingBridge.swift
@@ -1,0 +1,121 @@
+#if os(iOS)
+import Foundation
+import MediaPlayer
+
+/// iOS Now Playing detection via MPNowPlayingInfoCenter.
+@MainActor
+class MPNowPlayingBridge: ObservableObject {
+    static let shared = MPNowPlayingBridge()
+
+    @Published var activeSources: [String: SystemNowPlaying] = [:]
+    @Published var currentTrack: SystemNowPlaying?
+    @Published var isPlaying: Bool = false
+
+    var onTrackChange: ((SystemNowPlaying?) -> Void)?
+
+    private var pollTimer: Timer?
+    private var isListening = false
+    private var cachedArtwork: PlatformImage?
+    private var cachedArtworkTrackKey: String?
+
+    private init() {}
+
+    func startListening() {
+        guard !isListening else { return }
+        isListening = true
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(nowPlayingChanged),
+            name: .MPMusicPlayerControllerNowPlayingItemDidChange,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(playbackStateChanged),
+            name: .MPMusicPlayerControllerPlaybackStateDidChange,
+            object: nil
+        )
+
+        MPMusicPlayerController.systemMusicPlayer.beginGeneratingPlaybackNotifications()
+
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.pollNowPlaying()
+            }
+        }
+
+        pollNowPlaying()
+    }
+
+    func stopListening() {
+        guard isListening else { return }
+        isListening = false
+        MPMusicPlayerController.systemMusicPlayer.endGeneratingPlaybackNotifications()
+        NotificationCenter.default.removeObserver(self)
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    @objc private func nowPlayingChanged() {
+        cachedArtwork = nil
+        cachedArtworkTrackKey = nil
+        pollNowPlaying()
+    }
+
+    @objc private func playbackStateChanged() {
+        pollNowPlaying()
+    }
+
+    private func pollNowPlaying() {
+        let player = MPMusicPlayerController.systemMusicPlayer
+        guard let item = player.nowPlayingItem else {
+            if isPlaying {
+                isPlaying = false
+            }
+            return
+        }
+
+        let title = item.title ?? ""
+        guard !title.isEmpty else { return }
+
+        let artist = item.artist ?? ""
+        let album = item.albumTitle ?? ""
+        let duration = item.playbackDuration
+        let elapsed = player.currentPlaybackTime
+        let rate: Double = player.playbackState == .playing ? 1.0 : 0.0
+        let trackKey = "\(artist)|\(title)"
+
+        // Only re-render artwork when the track changes
+        if trackKey != cachedArtworkTrackKey {
+            cachedArtworkTrackKey = trackKey
+            cachedArtwork = item.artwork?.image(at: CGSize(width: 300, height: 300))
+        }
+
+        let bundleId = "com.apple.Music"
+        let track = SystemNowPlaying(
+            title: title, artist: artist, album: album,
+            duration: duration, elapsed: elapsed, playbackRate: rate,
+            artwork: cachedArtwork, sourceBundleId: bundleId,
+            sourceAppName: "Music", timestamp: Date()
+        )
+
+        let isNew = currentTrack?.title != track.title || currentTrack?.artist != track.artist
+        let playingChanged = isPlaying != (rate > 0)
+
+        // Only update @Published properties when something actually changed
+        if isNew || playingChanged || (rate > 0 && currentTrack?.elapsed != track.elapsed) {
+            activeSources[bundleId] = track
+            currentTrack = track
+        }
+
+        if playingChanged {
+            isPlaying = rate > 0
+        }
+
+        if isNew && track.isPlaying {
+            onTrackChange?(track)
+        }
+    }
+}
+#endif

--- a/ScrobbleNowiOS/ScrobbleNowiOSApp.swift
+++ b/ScrobbleNowiOS/ScrobbleNowiOSApp.swift
@@ -1,0 +1,53 @@
+#if os(iOS)
+import SwiftUI
+
+@main
+struct ScrobbleNowiOSApp: App {
+    @StateObject private var viewModel = NowPlayingViewModel()
+    @StateObject private var settings = SettingsManager.shared
+    @StateObject private var scrobbler = SystemScrobbleService.shared
+
+    init() {
+        KeychainService.bootstrapDefaults()
+        MPNowPlayingBridge.shared.startListening()
+
+        let vm = viewModel
+        SystemScrobbleService.shared.onScrobbleSuccess = {
+            Task { await vm.refresh() }
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            TabView {
+                NowPlayingView(viewModel: viewModel, settings: settings, scrobbler: scrobbler)
+                    .tabItem {
+                        Label("Feed", systemImage: "waveform")
+                    }
+
+                LibraryView { _, _ in }
+                    .tabItem {
+                        Label("Library", systemImage: "square.stack")
+                    }
+
+                CollageView()
+                    .tabItem {
+                        Label("Collage", systemImage: "square.grid.3x3")
+                    }
+
+                HistoryView { _, _ in }
+                    .tabItem {
+                        Label("History", systemImage: "clock.arrow.circlepath")
+                    }
+
+                StatisticsView()
+                    .tabItem {
+                        Label("Stats", systemImage: "chart.bar")
+                    }
+            }
+            .environment(\.appAccent, AppAccent.color(for: settings.accentColorName))
+            .tint(AppAccent.color(for: settings.accentColorName))
+        }
+    }
+}
+#endif

--- a/project.yml
+++ b/project.yml
@@ -3,13 +3,13 @@ options:
   bundleIdPrefix: com.personal
   deploymentTarget:
     macOS: "14.0"
+    iOS: "17.0"
   xcodeVersion: "16.0"
   minimumXcodeGenVersion: "2.0"
 
 settings:
   base:
     SWIFT_VERSION: "5.9"
-    MACOSX_DEPLOYMENT_TARGET: "14.0"
 
 targets:
   ScrobbleNow:
@@ -17,6 +17,8 @@ targets:
     platform: macOS
     sources:
       - path: ScrobbleNow
+        excludes:
+          - "**/.DS_Store"
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.personal.ScrobbleNow
@@ -29,6 +31,7 @@ targets:
         COMBINE_HIDPI_IMAGES: YES
         DEVELOPMENT_TEAM: YNB3ADRMFC
         CODE_SIGN_STYLE: Automatic
+        MACOSX_DEPLOYMENT_TARGET: "14.0"
     info:
       path: ScrobbleNow/Resources/Info.plist
       properties:
@@ -36,3 +39,31 @@ targets:
         CFBundleDisplayName: "Scrobble Now"
         NSAppTransportSecurity:
           NSAllowsArbitraryLoads: true
+
+  ScrobbleNowiOS:
+    type: application
+    platform: iOS
+    sources:
+      - path: ScrobbleNow
+        excludes:
+          - "App/ScrobbleNowApp.swift"
+          - "Services/MediaRemoteBridge.swift"
+          - "Services/MetricsService.swift"
+          - "Resources/Info.plist"
+          - "**/.DS_Store"
+      - path: ScrobbleNowiOS
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.personal.ScrobbleNow.ios
+        INFOPLIST_FILE: ""
+        GENERATE_INFOPLIST_FILE: YES
+        MARKETING_VERSION: "1.0.0"
+        CURRENT_PROJECT_VERSION: "1"
+        PRODUCT_NAME: "Scrobble Now"
+        DEVELOPMENT_TEAM: YNB3ADRMFC
+        CODE_SIGN_STYLE: Automatic
+        IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        INFOPLIST_KEY_CFBundleDisplayName: "Scrobble Now"
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoads: YES


### PR DESCRIPTION
## Summary
- Adds iOS target sharing all services, models, and views with the macOS app
- Uses `#if os()` conditionals and `PlatformImage` typealias for cross-platform compatibility
- iOS uses `TabView` navigation, `MPNowPlayingBridge` for local detection, and Last.fm as a cloud now-playing provider
- Collage rendering uses `UIGraphicsImageRenderer` on iOS, clipboard via `UIPasteboard`
- Expanded now-playing view with larger album art (300×300) on iOS
- macOS build verified — no regressions

## Test plan
- [x] macOS target builds and runs (BUILD SUCCEEDED)
- [x] iOS target builds (BUILD SUCCEEDED)
- [x] iOS app runs in simulator with Last.fm feed working
- [x] Expanded now-playing view persists through Last.fm poll cycles
- [x] No secrets in committed files
- [ ] Test on physical iPhone via Xcode or TestFlight

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)